### PR TITLE
feat: add default github clonable repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
       name="github-repo-url"
       id="github-repo-url"
       placeholder="GitHub Repository URL"
+      value="https://github.com/Chaphasilor/git-clone-pwa"
     >
     <br>
     <button


### PR DESCRIPTION
But why?

The Current implementation does not have a default url. Since it is a proof of concept - any github repo url will do: this one would be a perfect candidate. Second, it eliminates uncertainty in the eyes of users - they can choose this repo, or another one.